### PR TITLE
Added temporary noise fix to ham pendulum

### DIFF
--- a/src/deepbench/physics_object/hamiltonian_pendulum.py
+++ b/src/deepbench/physics_object/hamiltonian_pendulum.py
@@ -119,6 +119,14 @@ class HamiltonianPendulum(Pendulum):
         dydt = np.stack(dydt).T
         dqdt, dpdt = np.split(dydt, 2)  # split the dydt into dqdt and dpdt
 
+        # add noise
+        noise_std = 0.1
+        q += (
+            np.random.randn(*q.shape) * noise_std
+        )  # creates a random array of size q.shape and is scaled with noise_std then adds to q for noise
+        p += (
+            np.random.randn(*p.shape) * noise_std
+        )  # creates a random array of size p.shape and is scaled with noise_std then adds to p for noise
         return q, p, dqdt, dpdt, t_eval
 
     def get_field(self, xmin=-1.2, xmax=1.2, ymin=-1.2, ymax=1.2, gridsize=20):


### PR DESCRIPTION
In the `hamiltonian_pendulum` file, I added a few lines of code that generate noise on the q and p values inside the `simulate_pendulum_dynamics` function.  This is just a temporary fix while we plan to construct a permanent path to incorporate the noise module.